### PR TITLE
feature: integrate StatsCollector into LoadEngine

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ feature: add stats collector
 Brief summary of changes.
 
 ## How to verify
-./mvnw test
+./mvnw verify
 
 Closes #<issue-number>
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,9 @@ Use `./mvnw` instead of `mvn` (ensures same Maven version for everyone)
     git checkout -b feature/stats-collector
     ```
 6. Write code and tests
-7. Validate locally (see the [Suppressing Checkstyle Warnings](#suppressing-checkstyle-warnings) section): 
+7. Verify locally (see the [Suppressing Checkstyle Warnings](#suppressing-checkstyle-warnings) section): 
     ```bash
-    ./mvnw test
+    ./mvnw verify
     ```
 8. Commit with a clear message in English ([Conventional Naming Style](#conventional-naming-style) recommended, but not strict):
    ```bash

--- a/volta-agent/src/main/java/com/volta/agent/engine/LoadEngine.java
+++ b/volta-agent/src/main/java/com/volta/agent/engine/LoadEngine.java
@@ -1,6 +1,8 @@
 package com.volta.agent.engine;
 
 import com.volta.agent.http.HttpSender;
+import com.volta.stats.StatsCollector;
+import com.volta.stats.StatsSnapshot;
 import java.net.http.HttpResponse;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -10,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 public class LoadEngine {
   private static final Logger log = LoggerFactory.getLogger(LoadEngine.class);
+  private final StatsCollector collector = new StatsCollector();
 
   private final String url;
   private final int targetRps;
@@ -29,7 +32,6 @@ public class LoadEngine {
     }
 
     this.url = url;
-
     this.targetRps = targetRps;
     this.durationSeconds = durationSeconds;
   }
@@ -44,6 +46,12 @@ public class LoadEngine {
 
     try (HttpSender sender = new HttpSender();
         ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+
+      // sender warmup. TODO
+      //      try (HttpSender sender = new HttpSender()) {
+      //        sender.send(baseUrl + "/test");
+      //      } catch (Exception ignored) {
+      //      }
 
       while (running && System.nanoTime() < endTime) {
 
@@ -67,10 +75,17 @@ public class LoadEngine {
 
         executor.submit(
             () -> {
+              long startNano = System.nanoTime();
               try {
                 HttpResponse<String> response = sender.send(url);
-                log.info("Status: {}, Body: {}", response.statusCode(), response.body());
+                long latencyMs = (System.nanoTime() - startNano) / 1_000_000;
+
+                collector.record(response.statusCode(), latencyMs);
+                log.info("Status: {}", response.statusCode());
               } catch (Exception e) {
+                long latencyMs = (System.nanoTime() - startNano) / 1_000_000;
+
+                collector.record(503, latencyMs);
                 log.error("Request failed", e);
               } finally {
                 semaphore.release();
@@ -90,6 +105,14 @@ public class LoadEngine {
     // try-with-resources handles executor.close() and sender.close()
     running = false;
     log.info("Test finished");
+  }
+
+  public StatsSnapshot getStats() {
+    return collector.getSnapshot();
+  }
+
+  public StatsSnapshot getStatsAndReset() {
+    return collector.getSnapshotAndReset();
   }
 
   public void stop() {

--- a/volta-agent/src/test/java/com/volta/agent/engine/LoadEngineStatsCollectorIT.java
+++ b/volta-agent/src/test/java/com/volta/agent/engine/LoadEngineStatsCollectorIT.java
@@ -1,0 +1,100 @@
+package com.volta.agent.engine;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import com.volta.stats.StatsSnapshot;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class LoadEngineStatsCollectorIT {
+  private WireMockServer wireMock;
+  private String baseUrl;
+
+  @BeforeEach
+  void setUp() {
+    wireMock = new WireMockServer(wireMockConfig().dynamicPort());
+    wireMock.start();
+    baseUrl = "http://localhost:" + wireMock.port();
+  }
+
+  @AfterEach
+  void tearDown() {
+    wireMock.stop();
+  }
+
+  @Test
+  void successfulRequestsAreRecordedInStats() {
+    wireMock.stubFor(get("/test").willReturn(ok()));
+
+    int rps = 5;
+    int duration = 2;
+    LoadEngine engine = new LoadEngine(baseUrl + "/test", rps, duration);
+    engine.start();
+
+    StatsSnapshot stats = engine.getStatsAndReset();
+    int expected = rps * duration;
+
+    assertTrue(
+        stats.totalRequests() >= expected * 0.8,
+        "Expected at least " + (int) (expected * 0.8) + " requests, got " + stats.totalRequests());
+    assertEquals(stats.totalRequests(), stats.successCount(), "All requests should be successful");
+    assertEquals(0, stats.errorCount());
+    assertTrue(stats.avgLatencyMs() >= 0);
+  }
+
+  @Test
+  void serverErrorsAreRecordedAsErrors() {
+    wireMock.stubFor(get("/error").willReturn(serverError()));
+
+    LoadEngine engine = new LoadEngine(baseUrl + "/error", 5, 2);
+    engine.start();
+
+    StatsSnapshot stats = engine.getStatsAndReset();
+    assertTrue(stats.totalRequests() > 0);
+    assertEquals(0, stats.successCount());
+    assertEquals(stats.totalRequests(), stats.errorCount());
+  }
+
+  @Test
+  void networkFailuresAreRecordedAsErrors() {
+    LoadEngine engine = new LoadEngine("http://invalid-host-that-does-not-exist:9999/test", 5, 2);
+    engine.start();
+
+    StatsSnapshot stats = engine.getStatsAndReset();
+    assertTrue(stats.totalRequests() > 0);
+    assertEquals(0, stats.successCount());
+    assertEquals(stats.totalRequests(), stats.errorCount());
+  }
+
+  @Test
+  void mixedResponsesAreRecordedCorrectly() {
+    wireMock.stubFor(
+        get("/mixed")
+            .inScenario("mixed")
+            .whenScenarioStateIs(Scenario.STARTED)
+            .willReturn(ok())
+            .willSetStateTo("error"));
+    wireMock.stubFor(
+        get("/mixed")
+            .inScenario("mixed")
+            .whenScenarioStateIs("error")
+            .willReturn(serverError())
+            .willSetStateTo(Scenario.STARTED));
+
+    LoadEngine engine = new LoadEngine(baseUrl + "/mixed", 10, 2);
+    engine.start();
+
+    StatsSnapshot stats = engine.getStatsAndReset();
+    assertTrue(stats.successCount() > 0, "Should have some successes");
+    assertTrue(stats.errorCount() > 0, "Should have some errors");
+    assertEquals(
+        stats.totalRequests(),
+        stats.successCount() + stats.errorCount(),
+        "total = success + errors");
+  }
+}

--- a/volta-agent/src/test/java/com/volta/agent/engine/LoadEngineTest.java
+++ b/volta-agent/src/test/java/com/volta/agent/engine/LoadEngineTest.java
@@ -5,7 +5,6 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.volta.agent.http.HttpSender;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,7 +13,6 @@ class LoadEngineTest {
 
   private WireMockServer wireMock;
   private String baseUrl;
-  private HttpSender sender;
 
   @BeforeEach
   void setUp() {
@@ -22,18 +20,10 @@ class LoadEngineTest {
     wireMock.start();
     wireMock.stubFor(get("/test").willReturn(ok("OK")));
     baseUrl = "http://localhost:" + wireMock.port();
-
-    try (HttpSender sender = new HttpSender()) {
-      sender.send(baseUrl + "/test");
-    } catch (Exception ignored) {
-    }
   }
 
   @AfterEach
   void tearDown() throws Exception {
-    if (sender != null) {
-      sender.close();
-    }
     wireMock.stop();
   }
 


### PR DESCRIPTION
## What
- Add StatsCollector field to LoadEngine, after each HTTP response collector records statusCode and latencyMs. Failed requests (exceptions) records as errors with statusCode=503.
- Add getStats() and getStatsAndReset() methods on LoadEngine that returns StatsSnapshot
- Removed warmup section from LoadEnginTest
- Add LoadEngineStatsCollector integrations tests

## How to verify
./mvnw verify

Closes #26 