### PR TITLE
feature: implement AgentClient in Master and add tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
                 <artifactId>logback-classic</artifactId>
                 <version>${logback.version}</version>
             </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/volta-agent/pom.xml
+++ b/volta-agent/pom.xml
@@ -28,6 +28,7 @@
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock-jetty12</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/volta-common/pom.xml
+++ b/volta-common/pom.xml
@@ -14,10 +14,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>

--- a/volta-master/pom.xml
+++ b/volta-master/pom.xml
@@ -33,11 +33,10 @@
         <dependency>
             <groupId>com.volta</groupId>
             <artifactId>volta-common</artifactId>
-            <!-- excluded to avoid conflict with Spring Boot's logback managed by starter-logging -->
             <exclusions>
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -52,6 +51,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-jetty12</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/volta-master/src/main/java/com/volta/master/MasterMain.java
+++ b/volta-master/src/main/java/com/volta/master/MasterMain.java
@@ -4,8 +4,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class VoltaMasterApplication {
+public class MasterMain {
   public static void main(String[] args) {
-    SpringApplication.run(VoltaMasterApplication.class, args);
+    SpringApplication.run(MasterMain.class, args);
   }
 }

--- a/volta-master/src/main/java/com/volta/master/client/AgentClient.java
+++ b/volta-master/src/main/java/com/volta/master/client/AgentClient.java
@@ -1,0 +1,27 @@
+package com.volta.master.client;
+
+import com.volta.model.TestConfig;
+import com.volta.stats.StatsSnapshot;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class AgentClient {
+  private final RestClient restClient;
+
+  public AgentClient(RestClient.Builder builder) {
+    this.restClient = builder.build();
+  }
+
+  public void startTest(String agentUrl, TestConfig config) {
+    restClient.post().uri(agentUrl + "/start").body(config).retrieve().toBodilessEntity();
+  }
+
+  public void stopTest(String agentUrl) {
+    restClient.post().uri(agentUrl + "/stop").retrieve().toBodilessEntity();
+  }
+
+  public StatsSnapshot getStats(String agentUrl) {
+    return restClient.get().uri(agentUrl + "/stats").retrieve().body(StatsSnapshot.class);
+  }
+}

--- a/volta-master/src/test/java/com/volta/master/client/AgentClientTest.java
+++ b/volta-master/src/test/java/com/volta/master/client/AgentClientTest.java
@@ -1,0 +1,87 @@
+package com.volta.master.client;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.volta.model.TestConfig;
+import com.volta.stats.StatsSnapshot;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+class AgentClientTest {
+
+  private WireMockServer wireMock;
+  private AgentClient agentClient;
+  private String agentUrl;
+
+  @BeforeEach
+  void setUp() {
+    wireMock = new WireMockServer(wireMockConfig().dynamicPort());
+    wireMock.start();
+    agentUrl = "http://localhost:" + wireMock.port();
+
+    agentClient = new AgentClient(RestClient.builder());
+  }
+
+  @AfterEach
+  void tearDown() {
+    wireMock.stop();
+  }
+
+  @Test
+  void startTestSendsPostRequest() {
+    wireMock.stubFor(post("/start").willReturn(ok()));
+
+    TestConfig config = new TestConfig("http://example.com", 10, 5);
+    agentClient.startTest(agentUrl, config);
+
+    wireMock.verify(postRequestedFor(urlEqualTo("/start")));
+  }
+
+  @Test
+  void stopTestSendsPostRequest() {
+    wireMock.stubFor(post("/stop").willReturn(ok()));
+
+    agentClient.stopTest(agentUrl);
+
+    wireMock.verify(postRequestedFor(urlEqualTo("/stop")));
+  }
+
+  @Test
+  void getStatsReturnsParsedResponse() {
+    String statsJson =
+        """
+            {
+              "totalRequests": 100,
+              "successCount": 95,
+              "errorCount": 5,
+              "avgLatencyMs": 50.5,
+              "minLatencyMs": 10,
+              "maxLatencyMs": 200
+            }
+            """;
+
+    wireMock.stubFor(
+        get("/stats").willReturn(ok(statsJson).withHeader("Content-Type", "application/json")));
+
+    StatsSnapshot stats = agentClient.getStats(agentUrl);
+
+    assertEquals(100, stats.totalRequests());
+    assertEquals(95, stats.successCount());
+    assertEquals(5, stats.errorCount());
+  }
+
+  @Test
+  void startTestSendsJsonBody() {
+    wireMock.stubFor(post("/start").withRequestBody(matchingJsonPath("$.url")).willReturn(ok()));
+
+    TestConfig config = new TestConfig("http://example.com", 10, 5);
+    agentClient.startTest(agentUrl, config);
+
+    wireMock.verify(postRequestedFor(urlEqualTo("/start")));
+  }
+}


### PR DESCRIPTION
## What
Implement AgentClient in Master module to communicate with Agent.

Added:
- `AgentClient` as Spring `@Component` wrapping `RestClient`
- `startTest(agentUrl, config)` — POST /start with test parameters
- `stopTest(agentUrl)` — POST /stop to stop running test
- `getStats(agentUrl)` — GET /stats returning `StatsSnapshot`
- Tests verifying HTTP communication:
  - POST /start request with JSON body
  - POST /stop request
  - GET /stats response parsing
  - Request body parameter validation

## How to verify
./mvnw verify

Closes #29 