### PR TITLE
feat: add multi-agent cluster support with failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Distributed load testing system for HTTP services with AI-powered analysis.
 - Java 21+
 
 ## Quick Start
+
 ### 1. Build
 
 ```bash
@@ -17,24 +18,26 @@ cd volta
 ./mvnw package -DskipTests
 ```
 
-### 2. Start the Agent (Terminal 1)
+### 2. Start an Agent
 
-The Agent listens for commands on port **7070** by default.
+The agent listens for commands on port **7070** by default. Pass a port as the first argument to run on another port:
 
 ```bash
 java -jar volta-agent/target/volta-agent-1.0-SNAPSHOT.jar
+java -jar volta-agent/target/volta-agent-1.0-SNAPSHOT.jar 7071
 ```
 
 Expected output:
+
 ```
 Agent started on port 7070
 ```
 
-### 3. Run the Master (Terminal 2)
+### 3. Run the Master
 
-#### Option A (recommended): run from config file
+#### Option A (recommended): config file
 
-Create a config file (JSON/YAML). Example `config.json`:
+Create `config.json`:
 
 ```json
 {
@@ -52,7 +55,7 @@ rps: 5
 duration: 10
 ```
 
-Run:
+Run with one agent:
 
 ```bash
 java -jar volta-master/target/volta-master-1.0-SNAPSHOT.jar \
@@ -60,7 +63,7 @@ java -jar volta-master/target/volta-master-1.0-SNAPSHOT.jar \
   --agent=localhost:7070
 ```
 
-#### Option B (legacy, still supported): pass parameters via CLI flags
+#### Option B: CLI flags
 
 ```bash
 java -jar volta-master/target/volta-master-1.0-SNAPSHOT.jar \
@@ -70,12 +73,15 @@ java -jar volta-master/target/volta-master-1.0-SNAPSHOT.jar \
   --agent=localhost:7070
 ```
 
-Stats file (optional): `--stats-out=path`
+#### Stats file (optional)
+
+`--stats-out=path`
 
 - Ends with `.csv` → header row + CSV lines (`sample` each second + one `final` row).
 - Any other suffix (for example `.jsonl`) → one JSON object per line (serialized `StatsSnapshot`).
 
 Expected output:
+
 ```
 [RPS: 0 | Success: 0.0% | Avg: 0ms | Errors: 0]
 [RPS: 4 | Success: 100.0% | Avg: 353ms | Errors: 0]
@@ -92,6 +98,65 @@ Min Latency:     114ms
 Max Latency:     863ms
 ===============================
 ```
+
+## Multi-Agent Cluster
+
+Master can orchestrate several agents at once. Total RPS from the config is split evenly across available agents.
+
+Example with **4 agents** and **40 RPS** (10 RPS per agent):
+
+**Terminals 1–4 — agents:**
+
+```bash
+java -jar volta-agent/target/volta-agent-1.0-SNAPSHOT.jar
+java -jar volta-agent/target/volta-agent-1.0-SNAPSHOT.jar 7071
+java -jar volta-agent/target/volta-agent-1.0-SNAPSHOT.jar 7072
+java -jar volta-agent/target/volta-agent-1.0-SNAPSHOT.jar 7073
+```
+
+**Terminal 5 — master:**
+
+```bash
+java -jar volta-master/target/volta-master-1.0-SNAPSHOT.jar \
+  --config=./config.json \
+  --agent=localhost:7070 \
+  --agent=localhost:7071 \
+  --agent=localhost:7072 \
+  --agent=localhost:7073
+```
+
+Repeat `--agent=host:port` for each worker. Agents can run on different machines — use their IP instead of `localhost`.
+
+**Tips:**
+
+- Set `rps` ≥ number of agents so every agent gets at least 1 RPS.
+- Master aggregates stats from all agents into a single live report and final summary.
+
+## Failover
+
+If an agent becomes unavailable during a test, master:
+
+1. Marks it as dead and logs a warning.
+2. Redistributes its RPS share across the remaining agents.
+3. Notes incomplete data in the final report if any agent was lost.
+
+At startup, unreachable agents are skipped; the test runs on the agents that respond. Master exits with an error only when no agents are reachable.
+
+Example warning during a test:
+
+```
+WARNING: agent unavailable (failed during test): http://localhost:7071
+WARNING: redistributed load for http://localhost:7070: 10 -> 14 rps
+```
+
+## Agent HTTP API
+
+| Endpoint       | Method | Description                          |
+|----------------|--------|--------------------------------------|
+| `/start`       | POST   | Start load test (`TestConfig` JSON)  |
+| `/stop`        | POST   | Stop current test                    |
+| `/stats`       | GET    | Return cumulative stats              |
+| `/change-rps`  | POST   | Change RPS mid-test (`{"rps": N}`)   |
 
 ## Contributing
 

--- a/volta-agent/src/main/java/com/volta/agent/core/AgentRuntime.java
+++ b/volta-agent/src/main/java/com/volta/agent/core/AgentRuntime.java
@@ -49,4 +49,12 @@ public class AgentRuntime {
   public synchronized boolean isRunning() {
     return isRunning;
   }
+
+  public synchronized boolean changeRps(int rps) {
+    if (!isRunning || currentEngine == null) {
+      return false;
+    }
+    currentEngine.updateTargetRps(rps);
+    return true;
+  }
 }

--- a/volta-agent/src/main/java/com/volta/agent/engine/LoadEngine.java
+++ b/volta-agent/src/main/java/com/volta/agent/engine/LoadEngine.java
@@ -15,7 +15,7 @@ public class LoadEngine {
   private final StatsCollector collector = new StatsCollector();
 
   private final String url;
-  private final int targetRps;
+  private volatile int targetRps;
   private final int durationSeconds;
   private volatile boolean running = false;
   private static final int MAX_CONCURRENT_REQUESTS = 1000;
@@ -36,9 +36,15 @@ public class LoadEngine {
     this.durationSeconds = durationSeconds;
   }
 
+  public void updateTargetRps(int newRps) {
+    if (newRps <= 0) {
+      throw new IllegalArgumentException("RPS must be positive");
+    }
+    this.targetRps = newRps;
+  }
+
   public void start() {
     running = true;
-    long intervalNanos = 1_000_000_000L / targetRps;
     long endTime;
     long sendNextTime;
 
@@ -55,6 +61,7 @@ public class LoadEngine {
       sendNextTime = System.nanoTime();
 
       while (running && System.nanoTime() < endTime) {
+        long intervalNanos = 1_000_000_000L / targetRps;
 
         long waitMillis = (sendNextTime - System.nanoTime()) / 1_000_000;
 

--- a/volta-agent/src/main/java/com/volta/agent/http/AgentHttpServer.java
+++ b/volta-agent/src/main/java/com/volta/agent/http/AgentHttpServer.java
@@ -2,6 +2,7 @@ package com.volta.agent.http;
 
 import com.sun.net.httpserver.HttpServer;
 import com.volta.agent.core.AgentRuntime;
+import com.volta.agent.http.handler.ChangeRpsHandler;
 import com.volta.agent.http.handler.StartHandler;
 import com.volta.agent.http.handler.StatsHandler;
 import com.volta.agent.http.handler.StopHandler;
@@ -21,6 +22,7 @@ public class AgentHttpServer {
     server.createContext("/start", new StartHandler(runtime));
     server.createContext("/stop", new StopHandler(runtime));
     server.createContext("/stats", new StatsHandler(runtime));
+    server.createContext("/change-rps", new ChangeRpsHandler(runtime));
   }
 
   public void start() {

--- a/volta-agent/src/main/java/com/volta/agent/http/handler/ChangeRpsHandler.java
+++ b/volta-agent/src/main/java/com/volta/agent/http/handler/ChangeRpsHandler.java
@@ -1,0 +1,63 @@
+package com.volta.agent.http.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.volta.agent.core.AgentRuntime;
+import com.volta.model.RpsChange;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class ChangeRpsHandler implements HttpHandler {
+  private final AgentRuntime runtime;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  public ChangeRpsHandler(AgentRuntime runtime) {
+    this.runtime = runtime;
+  }
+
+  @Override
+  public void handle(HttpExchange exchange) throws IOException {
+    if (!exchange.getRequestMethod().equals("POST")) {
+      exchange.sendResponseHeaders(405, -1);
+      return;
+    }
+
+    String json = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+
+    RpsChange change;
+    try {
+      change = objectMapper.readValue(json, RpsChange.class);
+    } catch (Exception e) {
+      String error = "Invalid JSON";
+      byte[] errorBytes = error.getBytes(StandardCharsets.UTF_8);
+      exchange.sendResponseHeaders(400, errorBytes.length);
+      exchange.getResponseBody().write(errorBytes);
+      exchange.close();
+      return;
+    }
+
+    boolean updated;
+    try {
+      updated = runtime.changeRps(change.rps());
+    } catch (IllegalArgumentException e) {
+      String error = "Invalid parameters: " + e.getMessage();
+      byte[] errorBytes = error.getBytes(StandardCharsets.UTF_8);
+      exchange.sendResponseHeaders(400, errorBytes.length);
+      exchange.getResponseBody().write(errorBytes);
+      exchange.close();
+      return;
+    }
+
+    if (updated) {
+      String response = "RPS updated";
+      byte[] responseBytes = response.getBytes(StandardCharsets.UTF_8);
+      exchange.sendResponseHeaders(200, responseBytes.length);
+      exchange.getResponseBody().write(responseBytes);
+    } else {
+      exchange.sendResponseHeaders(409, -1);
+    }
+
+    exchange.close();
+  }
+}

--- a/volta-agent/src/test/java/com/volta/agent/http/AgentHttpServerTest.java
+++ b/volta-agent/src/test/java/com/volta/agent/http/AgentHttpServerTest.java
@@ -45,6 +45,30 @@ class AgentHttpServerTest {
   }
 
   @Test
+  void changeRpsReturns200WhileTestIsRunning() throws Exception {
+    String payload =
+        """
+            {"url":"http://localhost:%d/test","rps":2,"duration":10}
+            """
+            .formatted(wireMock.port());
+
+    postJson(agentBaseUrl + "/start", payload);
+    Thread.sleep(200);
+
+    HttpResponse<String> response = postJson(agentBaseUrl + "/change-rps", "{\"rps\":10}");
+
+    assertEquals(200, response.statusCode());
+    assertTrue(response.body().contains("RPS updated"));
+  }
+
+  @Test
+  void changeRpsReturns409WhenTestIsNotRunning() throws Exception {
+    HttpResponse<String> response = postJson(agentBaseUrl + "/change-rps", "{\"rps\":10}");
+
+    assertEquals(409, response.statusCode());
+  }
+
+  @Test
   void startReturns200() throws Exception {
     String payload =
         """

--- a/volta-common/src/main/java/com/volta/model/RpsChange.java
+++ b/volta-common/src/main/java/com/volta/model/RpsChange.java
@@ -1,0 +1,3 @@
+package com.volta.model;
+
+public record RpsChange(int rps) {}

--- a/volta-common/src/main/java/com/volta/stats/StatsAggregator.java
+++ b/volta-common/src/main/java/com/volta/stats/StatsAggregator.java
@@ -1,0 +1,48 @@
+package com.volta.stats;
+
+import java.util.Collection;
+
+public final class StatsAggregator {
+
+  private StatsAggregator() {}
+
+  public static StatsSnapshot merge(Collection<StatsSnapshot> snapshots) {
+    if (snapshots.isEmpty()) {
+      return empty();
+    }
+    if (snapshots.size() == 1) {
+      return snapshots.iterator().next();
+    }
+
+    long totalRequests = 0;
+    long successCount = 0;
+    long errorCount = 0;
+    long minLatency = Long.MAX_VALUE;
+    long maxLatency = 0;
+    double weightedLatencySum = 0;
+
+    for (StatsSnapshot snapshot : snapshots) {
+      totalRequests += snapshot.totalRequests();
+      successCount += snapshot.successCount();
+      errorCount += snapshot.errorCount();
+
+      if (snapshot.totalRequests() > 0) {
+        weightedLatencySum += snapshot.avgLatencyMs() * snapshot.totalRequests();
+        minLatency = Math.min(minLatency, snapshot.minLatencyMs());
+        maxLatency = Math.max(maxLatency, snapshot.maxLatencyMs());
+      }
+    }
+
+    double avgLatency = totalRequests > 0 ? weightedLatencySum / totalRequests : 0.0;
+    if (minLatency == Long.MAX_VALUE) {
+      minLatency = 0;
+    }
+
+    return new StatsSnapshot(
+        totalRequests, successCount, errorCount, avgLatency, minLatency, maxLatency);
+  }
+
+  private static StatsSnapshot empty() {
+    return new StatsSnapshot(0, 0, 0, 0.0, 0, 0);
+  }
+}

--- a/volta-common/src/test/java/com/volta/stats/StatsAggregatorTest.java
+++ b/volta-common/src/test/java/com/volta/stats/StatsAggregatorTest.java
@@ -1,0 +1,54 @@
+package com.volta.stats;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StatsAggregatorTest {
+
+  @Test
+  void mergeEmptyReturnsZeros() {
+    StatsSnapshot merged = StatsAggregator.merge(List.of());
+
+    assertEquals(0, merged.totalRequests());
+    assertEquals(0, merged.successCount());
+    assertEquals(0.0, merged.avgLatencyMs());
+  }
+
+  @Test
+  void mergeSingleReturnsSameSnapshot() {
+    StatsSnapshot snapshot = new StatsSnapshot(100, 95, 5, 50.0, 10, 200);
+
+    StatsSnapshot merged = StatsAggregator.merge(List.of(snapshot));
+
+    assertEquals(snapshot, merged);
+  }
+
+  @Test
+  void mergeSumsCountsAndComputesWeightedAverage() {
+    StatsSnapshot first = new StatsSnapshot(100, 90, 10, 100.0, 20, 300);
+    StatsSnapshot second = new StatsSnapshot(200, 200, 0, 50.0, 10, 150);
+
+    StatsSnapshot merged = StatsAggregator.merge(List.of(first, second));
+
+    assertEquals(300, merged.totalRequests());
+    assertEquals(290, merged.successCount());
+    assertEquals(10, merged.errorCount());
+    assertEquals(10, merged.minLatencyMs());
+    assertEquals(300, merged.maxLatencyMs());
+    assertEquals(66.66666666666667, merged.avgLatencyMs(), 0.0001);
+  }
+
+  @Test
+  void mergeIgnoresEmptySnapshotsForMinMax() {
+    StatsSnapshot empty = new StatsSnapshot(0, 0, 0, 0.0, 0, 0);
+    StatsSnapshot active = new StatsSnapshot(50, 50, 0, 40.0, 15, 120);
+
+    StatsSnapshot merged = StatsAggregator.merge(List.of(empty, active));
+
+    assertEquals(50, merged.totalRequests());
+    assertEquals(15, merged.minLatencyMs());
+    assertEquals(120, merged.maxLatencyMs());
+  }
+}

--- a/volta-master/src/main/java/com/volta/master/StartupRunner.java
+++ b/volta-master/src/main/java/com/volta/master/StartupRunner.java
@@ -4,7 +4,9 @@ import com.volta.master.cli.ArgsException;
 import com.volta.master.cli.ArgsParser;
 import com.volta.master.cli.MasterArgs;
 import com.volta.master.client.AgentClient;
+import com.volta.master.cluster.AgentCluster;
 import com.volta.master.reporter.StatsReporter;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
@@ -35,16 +37,25 @@ public class StartupRunner implements ApplicationRunner {
       return;
     }
 
+    List<String> agentUrls = masterArgs.agentUrls();
+    AgentCluster cluster = AgentCluster.of(masterArgs.testConfig(), agentUrls);
+
     log.info(
-        "Starting test: url={}, rps={}, duration={}s, agent={}",
+        "Starting test: url={}, totalRps={}, duration={}s, agents={}",
         masterArgs.testConfig().url(),
         masterArgs.testConfig().rps(),
         masterArgs.testConfig().duration(),
-        masterArgs.agentUrl());
+        agentUrls);
 
-    agentClient.startTest(masterArgs.agentUrl(), masterArgs.testConfig());
+    try {
+      cluster.startCluster(agentClient);
+    } catch (IllegalStateException e) {
+      log.error(e.getMessage());
+      System.exit(1);
+      return;
+    }
 
     statsReporter.startReporting(
-        masterArgs.agentUrl(), masterArgs.testConfig().duration(), masterArgs.outputFile());
+        cluster, masterArgs.testConfig().duration(), masterArgs.outputFile());
   }
 }

--- a/volta-master/src/main/java/com/volta/master/cli/ArgsParser.java
+++ b/volta-master/src/main/java/com/volta/master/cli/ArgsParser.java
@@ -6,6 +6,8 @@ import com.volta.model.TestConfig;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.boot.ApplicationArguments;
 
@@ -13,10 +15,11 @@ public class ArgsParser {
 
   private static final String USAGE =
       """
-              Usage:   java -jar volta-master.jar --url=<url> --rps=<rps> --duration=<seconds> --agent=<host:port>
-                       java -jar volta-master.jar --config=./<config.json(.yaml/.yml)> --agent=<host:port>
+              Usage:   java -jar volta-master.jar --url=<url> --rps=<rps> --duration=<seconds> --agent=<host:port> [--agent=<host:port> ...]
+                       java -jar volta-master.jar --config=./<config.json(.yaml/.yml)> --agent=<host:port> [--agent=<host:port> ...]
 
               Example: java -jar volta-master.jar --url=https://httpbin.org/get --rps=10 --duration=30 --agent=localhost:7070
+                       java -jar volta-master.jar --url=https://httpbin.org/get --rps=100 --duration=30 --agent=localhost:7070 --agent=localhost:7071
                        java -jar volta-master.jar --config=./config.json --agent=localhost:7070 [--stats-out=report.jsonl|report.csv]
               """;
 
@@ -67,17 +70,14 @@ public class ArgsParser {
       validateUrl(url);
       testConfig = new TestConfig(url, rps, duration);
     }
-    String agent = requireString(args, "agent");
-    validateAgent(agent);
-
-    agent = "http://" + agent;
+    List<String> agentUrls = requireAgents(args);
 
     if (args.containsOption("stats-out")) {
       String outputFile = requireString(args, "stats-out");
-      return new MasterArgs(testConfig, Optional.of(outputFile), agent);
+      return new MasterArgs(testConfig, Optional.of(outputFile), agentUrls);
     }
 
-    return new MasterArgs(testConfig, Optional.empty(), agent);
+    return new MasterArgs(testConfig, Optional.empty(), agentUrls);
   }
 
   private static String requireString(ApplicationArguments args, String name) {
@@ -112,6 +112,28 @@ public class ArgsParser {
       throw new ArgsException(
           "Argument --url must start with http:// or https://, got: " + url + "\n" + USAGE);
     }
+  }
+
+  private static List<String> requireAgents(ApplicationArguments args) {
+    if (!args.containsOption("agent")) {
+      throw new ArgsException("Missing required argument: --agent\n" + USAGE);
+    }
+
+    List<String> rawAgents = args.getOptionValues("agent");
+    if (rawAgents == null || rawAgents.isEmpty()) {
+      throw new ArgsException("Missing required argument: --agent\n" + USAGE);
+    }
+
+    List<String> agentUrls = new ArrayList<>(rawAgents.size());
+    for (String agent : rawAgents) {
+      if (agent == null || agent.isBlank()) {
+        throw new ArgsException("Argument --agent must not be blank\n" + USAGE);
+      }
+      validateAgent(agent);
+      agentUrls.add("http://" + agent);
+    }
+
+    return List.copyOf(agentUrls);
   }
 
   private static void validateAgent(String agent) {

--- a/volta-master/src/main/java/com/volta/master/cli/MasterArgs.java
+++ b/volta-master/src/main/java/com/volta/master/cli/MasterArgs.java
@@ -1,6 +1,8 @@
 package com.volta.master.cli;
 
 import com.volta.model.TestConfig;
+import java.util.List;
 import java.util.Optional;
 
-public record MasterArgs(TestConfig testConfig, Optional<String> outputFile, String agentUrl) {}
+public record MasterArgs(
+    TestConfig testConfig, Optional<String> outputFile, List<String> agentUrls) {}

--- a/volta-master/src/main/java/com/volta/master/client/AgentClient.java
+++ b/volta-master/src/main/java/com/volta/master/client/AgentClient.java
@@ -1,12 +1,17 @@
 package com.volta.master.client;
 
+import com.volta.model.RpsChange;
 import com.volta.model.TestConfig;
 import com.volta.stats.StatsSnapshot;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 @Component
 public class AgentClient {
+  private static final Logger log = LoggerFactory.getLogger(AgentClient.class);
+
   private final RestClient restClient;
 
   public AgentClient(RestClient.Builder builder) {
@@ -17,11 +22,46 @@ public class AgentClient {
     restClient.post().uri(agentUrl + "/start").body(config).retrieve().toBodilessEntity();
   }
 
+  public boolean startTestSafe(String agentUrl, TestConfig config) {
+    try {
+      startTest(agentUrl, config);
+      return true;
+    } catch (Exception e) {
+      log.error("Failed to start test on {}: {}", agentUrl, e.getMessage());
+      return false;
+    }
+  }
+
   public void stopTest(String agentUrl) {
     restClient.post().uri(agentUrl + "/stop").retrieve().toBodilessEntity();
   }
 
+  public boolean changeRps(String agentUrl, int rps) {
+    try {
+      restClient
+          .post()
+          .uri(agentUrl + "/change-rps")
+          .body(new RpsChange(rps))
+          .retrieve()
+          .toBodilessEntity();
+      return true;
+    } catch (Exception e) {
+      log.error("Failed to change rps on {}: {}", agentUrl, e.getMessage());
+      return false;
+    }
+  }
+
   public StatsSnapshot getStats(String agentUrl) {
     return restClient.get().uri(agentUrl + "/stats").retrieve().body(StatsSnapshot.class);
+  }
+
+  public boolean isReachable(String agentUrl) {
+    try {
+      getStats(agentUrl);
+      return true;
+    } catch (Exception e) {
+      log.error("Agent unreachable {}: {}", agentUrl, e.getMessage());
+      return false;
+    }
   }
 }

--- a/volta-master/src/main/java/com/volta/master/cluster/AgentCluster.java
+++ b/volta-master/src/main/java/com/volta/master/cluster/AgentCluster.java
@@ -1,0 +1,151 @@
+package com.volta.master.cluster;
+
+import com.volta.master.client.AgentClient;
+import com.volta.model.TestConfig;
+import com.volta.stats.StatsAggregator;
+import com.volta.stats.StatsSnapshot;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class AgentCluster {
+  private static final Logger log = LoggerFactory.getLogger(AgentCluster.class);
+
+  private final TestConfig testConfig;
+  private final List<String> allAgentUrls;
+  private final Set<String> deadAgentUrls = new LinkedHashSet<>();
+  private final Map<String, Integer> assignedRps = new HashMap<>();
+
+  public AgentCluster(TestConfig testConfig, List<String> agentUrls) {
+    this.testConfig = testConfig;
+    this.allAgentUrls = List.copyOf(agentUrls);
+  }
+
+  public static AgentCluster of(TestConfig testConfig, List<String> agentUrls) {
+    return new AgentCluster(testConfig, agentUrls);
+  }
+
+  public List<String> allAgentUrls() {
+    return allAgentUrls;
+  }
+
+  public List<String> aliveAgentUrls() {
+    return allAgentUrls.stream().filter(url -> !deadAgentUrls.contains(url)).toList();
+  }
+
+  public List<String> deadAgentUrls() {
+    return List.copyOf(deadAgentUrls);
+  }
+
+  public boolean hasDeadAgents() {
+    return !deadAgentUrls.isEmpty();
+  }
+
+  public void startCluster(AgentClient agentClient) {
+    List<String> reachable = new ArrayList<>();
+    for (String agentUrl : allAgentUrls) {
+      if (agentClient.isReachable(agentUrl)) {
+        reachable.add(agentUrl);
+      } else {
+        markDead(agentUrl, "unreachable at startup");
+      }
+    }
+
+    if (reachable.isEmpty()) {
+      throw new IllegalStateException("No reachable agents");
+    }
+
+    startAgents(agentClient, reachable);
+  }
+
+  public StatsSnapshot fetchStatsWithFailover(AgentClient agentClient) {
+    List<StatsSnapshot> snapshots = new ArrayList<>();
+    Set<String> newlyDead = new HashSet<>();
+
+    for (String agentUrl : aliveAgentUrls()) {
+      try {
+        snapshots.add(agentClient.getStats(agentUrl));
+      } catch (Exception e) {
+        newlyDead.add(agentUrl);
+        log.error("Failed to fetch stats from {}: {}", agentUrl, e.getMessage());
+      }
+    }
+
+    if (!newlyDead.isEmpty()) {
+      for (String agentUrl : newlyDead) {
+        markDead(agentUrl, "failed during test");
+      }
+      redistributeLoad(agentClient);
+    }
+
+    return StatsAggregator.merge(snapshots);
+  }
+
+  private void startAgents(AgentClient agentClient, List<String> aliveAgents) {
+    List<Integer> rpsValues = LoadPlanner.splitRps(testConfig.rps(), aliveAgents.size());
+    assignedRps.clear();
+
+    for (int i = 0; i < aliveAgents.size(); i++) {
+      String agentUrl = aliveAgents.get(i);
+      int agentRps = rpsValues.get(i);
+      TestConfig agentConfig = new TestConfig(testConfig.url(), agentRps, testConfig.duration());
+
+      if (agentClient.startTestSafe(agentUrl, agentConfig)) {
+        assignedRps.put(agentUrl, agentRps);
+        log.info("Started agent {} with rps={}", agentUrl, agentRps);
+      } else {
+        markDead(agentUrl, "failed to start test");
+      }
+    }
+
+    if (assignedRps.isEmpty()) {
+      throw new IllegalStateException("Failed to start test on any agent");
+    }
+
+    if (assignedRps.size() < aliveAgents.size()) {
+      redistributeLoad(agentClient);
+    }
+  }
+
+  private void redistributeLoad(AgentClient agentClient) {
+    List<String> aliveAgents = aliveAgentUrls().stream().filter(assignedRps::containsKey).toList();
+    if (aliveAgents.isEmpty()) {
+      log.error("No alive agents left for load redistribution");
+      return;
+    }
+
+    List<Integer> rpsValues = LoadPlanner.splitRps(testConfig.rps(), aliveAgents.size());
+    for (int i = 0; i < aliveAgents.size(); i++) {
+      String agentUrl = aliveAgents.get(i);
+      int newRps = rpsValues.get(i);
+      int oldRps = assignedRps.getOrDefault(agentUrl, 0);
+
+      if (oldRps == newRps) {
+        continue;
+      }
+
+      if (agentClient.changeRps(agentUrl, newRps)) {
+        assignedRps.put(agentUrl, newRps);
+        log.warn("Redistributed load for {}: {} -> {} rps", agentUrl, oldRps, newRps);
+        System.out.printf(
+            "WARNING: redistributed load for %s: %d -> %d rps%n", agentUrl, oldRps, newRps);
+      } else {
+        markDead(agentUrl, "failed to change rps during failover");
+      }
+    }
+  }
+
+  private void markDead(String agentUrl, String reason) {
+    if (deadAgentUrls.add(agentUrl)) {
+      assignedRps.remove(agentUrl);
+      log.warn("Agent marked dead ({}): {}", reason, agentUrl);
+      System.out.printf("WARNING: agent unavailable (%s): %s%n", reason, agentUrl);
+    }
+  }
+}

--- a/volta-master/src/main/java/com/volta/master/cluster/LoadPlanner.java
+++ b/volta-master/src/main/java/com/volta/master/cluster/LoadPlanner.java
@@ -1,0 +1,38 @@
+package com.volta.master.cluster;
+
+import com.volta.model.TestConfig;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class LoadPlanner {
+
+  private LoadPlanner() {}
+
+  public static List<TestConfig> splitLoad(TestConfig config, int agentCount) {
+    if (agentCount <= 0) {
+      throw new IllegalArgumentException("agentCount must be positive");
+    }
+
+    List<Integer> rpsValues = splitRps(config.rps(), agentCount);
+    List<TestConfig> configs = new ArrayList<>(agentCount);
+    for (int rps : rpsValues) {
+      configs.add(new TestConfig(config.url(), rps, config.duration()));
+    }
+    return configs;
+  }
+
+  public static List<Integer> splitRps(int totalRps, int agentCount) {
+    if (agentCount <= 0) {
+      throw new IllegalArgumentException("agentCount must be positive");
+    }
+
+    int baseRps = totalRps / agentCount;
+    int remainder = totalRps % agentCount;
+
+    List<Integer> rpsValues = new ArrayList<>(agentCount);
+    for (int i = 0; i < agentCount; i++) {
+      rpsValues.add(baseRps + (i < remainder ? 1 : 0));
+    }
+    return rpsValues;
+  }
+}

--- a/volta-master/src/main/java/com/volta/master/reporter/StatsReporter.java
+++ b/volta-master/src/main/java/com/volta/master/reporter/StatsReporter.java
@@ -3,6 +3,7 @@ package com.volta.master.reporter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.volta.master.StartupRunner;
 import com.volta.master.client.AgentClient;
+import com.volta.master.cluster.AgentCluster;
 import com.volta.stats.StatsSnapshot;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -49,17 +50,20 @@ public class StatsReporter {
   }
 
   public void startReporting(
-      String agentUrl, int durationSeconds, Optional<String> outputFilePath) {
+      AgentCluster cluster, int durationSeconds, Optional<String> outputFilePath) {
 
-    log.info("Starting live stats reporting for {}s", durationSeconds);
+    log.info(
+        "Starting live stats reporting for {}s across {} agent(s)",
+        durationSeconds,
+        cluster.allAgentUrls().size());
 
     Optional<StatsFileSink> sink = openOptionalSink(outputFilePath);
     try {
-      runLoop(agentUrl, durationSeconds, sink);
+      runLoop(cluster, durationSeconds, sink);
       try {
-        StatsSnapshot finalStats = agentClient.getStats(agentUrl);
+        StatsSnapshot finalStats = cluster.fetchStatsWithFailover(agentClient);
         writeFinalToFile(sink, finalStats);
-        printFinalStats(finalStats);
+        printFinalStats(finalStats, cluster);
       } catch (Exception e) {
         log.error("Failed to fetch final stats: {}", e.getMessage());
       }
@@ -112,7 +116,7 @@ public class StatsReporter {
     }
   }
 
-  private void runLoop(String agentUrl, int durationSeconds, Optional<StatsFileSink> sink) {
+  private void runLoop(AgentCluster cluster, int durationSeconds, Optional<StatsFileSink> sink) {
 
     for (int i = 0; i < durationSeconds; i++) {
       try {
@@ -124,7 +128,7 @@ public class StatsReporter {
       }
 
       try {
-        StatsSnapshot stats = agentClient.getStats(agentUrl);
+        StatsSnapshot stats = cluster.fetchStatsWithFailover(agentClient);
         int elapsedSeconds = i + 1;
         printLiveStats(stats, elapsedSeconds);
         writeSampleToFile(sink, stats, elapsedSeconds);
@@ -253,9 +257,15 @@ public class StatsReporter {
     System.out.println(line);
   }
 
-  private void printFinalStats(StatsSnapshot finalStats) {
+  private void printFinalStats(StatsSnapshot finalStats, AgentCluster cluster) {
 
     System.out.println("\n" + BOLD + CYAN + "========= FINAL STATS =========" + RESET);
+
+    if (cluster.hasDeadAgents()) {
+      System.out.printf(
+          "%sWARNING: incomplete data, unavailable agents: %s%s%n",
+          YELLOW, cluster.deadAgentUrls(), RESET);
+    }
 
     System.out.printf("Total Requests:  %s%s%d%s\n", BOLD, BLUE, finalStats.totalRequests(), RESET);
     System.out.printf("Success:         %s%s%d%s\n", BOLD, GREEN, finalStats.successCount(), RESET);

--- a/volta-master/src/test/java/com/volta/master/cli/ArgsParserTest.java
+++ b/volta-master/src/test/java/com/volta/master/cli/ArgsParserTest.java
@@ -6,6 +6,7 @@ import com.volta.model.TestConfig;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.boot.DefaultApplicationArguments;
@@ -36,7 +37,7 @@ class ArgsParserTest {
     assertEquals("https://httpbin.org/get", config.url());
     assertEquals(10, config.rps());
     assertEquals(30, config.duration());
-    assertEquals("http://localhost:7070", result.agentUrl());
+    assertEquals("http://localhost:7070", result.agentUrls().get(0));
   }
 
   @Test
@@ -60,7 +61,21 @@ class ArgsParserTest {
     assertEquals("https://httpbin.org/get", config.url());
     assertEquals(10, config.rps());
     assertEquals(30, config.duration());
-    assertEquals("http://localhost:7070", result.agentUrl());
+    assertEquals("http://localhost:7070", result.agentUrls().get(0));
+  }
+
+  @Test
+  void multipleAgentsProduceCorrectMasterArgs() {
+    MasterArgs result =
+        ArgsParser.parse(
+            args(
+                "--url=https://httpbin.org/get",
+                "--rps=10",
+                "--duration=30",
+                "--agent=localhost:7070",
+                "--agent=localhost:7071"));
+
+    assertEquals(List.of("http://localhost:7070", "http://localhost:7071"), result.agentUrls());
   }
 
   @Test
@@ -149,7 +164,7 @@ class ArgsParserTest {
     assertEquals("https://httpbin.org/get", config.url());
     assertEquals(10, config.rps());
     assertEquals(30, config.duration());
-    assertEquals("http://localhost:7070", result.agentUrl());
+    assertEquals("http://localhost:7070", result.agentUrls().get(0));
   }
 
   @Test
@@ -171,7 +186,7 @@ class ArgsParserTest {
     assertEquals("https://httpbin.org/get", config.url());
     assertEquals(10, config.rps());
     assertEquals(30, config.duration());
-    assertEquals("http://localhost:7070", result.agentUrl());
+    assertEquals("http://localhost:7070", result.agentUrls().get(0));
   }
 
   @Test

--- a/volta-master/src/test/java/com/volta/master/cluster/AgentClusterTest.java
+++ b/volta-master/src/test/java/com/volta/master/cluster/AgentClusterTest.java
@@ -1,0 +1,86 @@
+package com.volta.master.cluster;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.volta.master.client.AgentClient;
+import com.volta.model.TestConfig;
+import com.volta.stats.StatsSnapshot;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class AgentClusterTest {
+
+  @Mock private AgentClient agentClient;
+
+  private TestConfig testConfig;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    testConfig = new TestConfig("https://example.com", 100, 30);
+  }
+
+  @Test
+  void startClusterSkipsUnreachableAgentsAndRedistributesLoad() {
+    when(agentClient.isReachable("http://localhost:7070")).thenReturn(true);
+    when(agentClient.isReachable("http://localhost:7071")).thenReturn(false);
+    when(agentClient.isReachable("http://localhost:7072")).thenReturn(true);
+    when(agentClient.startTestSafe(eq("http://localhost:7070"), any(TestConfig.class)))
+        .thenReturn(true);
+    when(agentClient.startTestSafe(eq("http://localhost:7072"), any(TestConfig.class)))
+        .thenReturn(true);
+
+    AgentCluster cluster =
+        AgentCluster.of(
+            testConfig,
+            List.of("http://localhost:7070", "http://localhost:7071", "http://localhost:7072"));
+
+    cluster.startCluster(agentClient);
+
+    assertEquals(List.of("http://localhost:7071"), cluster.deadAgentUrls());
+    assertEquals(
+        List.of("http://localhost:7070", "http://localhost:7072"), cluster.aliveAgentUrls());
+
+    verify(agentClient)
+        .startTestSafe("http://localhost:7070", new TestConfig("https://example.com", 50, 30));
+    verify(agentClient)
+        .startTestSafe("http://localhost:7072", new TestConfig("https://example.com", 50, 30));
+    verify(agentClient, never()).startTestSafe(eq("http://localhost:7071"), any());
+  }
+
+  @Test
+  void fetchStatsWithFailoverRedistributesLoadWhenAgentDies() {
+    when(agentClient.isReachable(anyString())).thenReturn(true);
+    when(agentClient.startTestSafe(anyString(), any(TestConfig.class))).thenReturn(true);
+    when(agentClient.getStats("http://localhost:7070"))
+        .thenReturn(new StatsSnapshot(10, 10, 0, 50.0, 10, 100));
+    when(agentClient.getStats("http://localhost:7071"))
+        .thenThrow(new RuntimeException("connection refused"))
+        .thenReturn(new StatsSnapshot(0, 0, 0, 0.0, 0, 0));
+    when(agentClient.changeRps("http://localhost:7070", 100)).thenReturn(true);
+
+    AgentCluster cluster =
+        AgentCluster.of(testConfig, List.of("http://localhost:7070", "http://localhost:7071"));
+    cluster.startCluster(agentClient);
+
+    StatsSnapshot stats = cluster.fetchStatsWithFailover(agentClient);
+
+    assertEquals(10, stats.totalRequests());
+    assertTrue(cluster.deadAgentUrls().contains("http://localhost:7071"));
+    verify(agentClient).changeRps("http://localhost:7070", 100);
+  }
+
+  @Test
+  void startClusterFailsWhenNoAgentsAreReachable() {
+    when(agentClient.isReachable(anyString())).thenReturn(false);
+
+    AgentCluster cluster =
+        AgentCluster.of(testConfig, List.of("http://localhost:7070", "http://localhost:7071"));
+
+    assertThrows(IllegalStateException.class, () -> cluster.startCluster(agentClient));
+  }
+}

--- a/volta-master/src/test/java/com/volta/master/cluster/LoadPlannerTest.java
+++ b/volta-master/src/test/java/com/volta/master/cluster/LoadPlannerTest.java
@@ -1,0 +1,48 @@
+package com.volta.master.cluster;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.volta.model.TestConfig;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LoadPlannerTest {
+
+  @Test
+  void splitRpsDistributesRemainderToFirstAgents() {
+    assertEquals(List.of(4, 3, 3), LoadPlanner.splitRps(10, 3));
+    assertEquals(10, LoadPlanner.splitRps(10, 3).stream().mapToInt(Integer::intValue).sum());
+  }
+
+  @Test
+  void splitLoadDistributesRemainderToFirstAgents() {
+    TestConfig config = new TestConfig("https://example.com", 10, 30);
+
+    List<TestConfig> split = LoadPlanner.splitLoad(config, 3);
+
+    assertEquals(3, split.size());
+    assertEquals(4, split.get(0).rps());
+    assertEquals(3, split.get(1).rps());
+    assertEquals(3, split.get(2).rps());
+    assertEquals(10, split.stream().mapToInt(TestConfig::rps).sum());
+    assertTrue(split.stream().allMatch(c -> c.url().equals(config.url())));
+    assertTrue(split.stream().allMatch(c -> c.duration() == config.duration()));
+  }
+
+  @Test
+  void splitLoadWithSingleAgentKeepsFullRps() {
+    TestConfig config = new TestConfig("https://example.com", 25, 10);
+
+    List<TestConfig> split = LoadPlanner.splitLoad(config, 1);
+
+    assertEquals(1, split.size());
+    assertEquals(25, split.get(0).rps());
+  }
+
+  @Test
+  void splitLoadRejectsNonPositiveAgentCount() {
+    TestConfig config = new TestConfig("https://example.com", 10, 10);
+
+    assertThrows(IllegalArgumentException.class, () -> LoadPlanner.splitLoad(config, 0));
+  }
+}

--- a/volta-master/src/test/java/com/volta/master/reporter/StatsReporterTest.java
+++ b/volta-master/src/test/java/com/volta/master/reporter/StatsReporterTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.volta.master.client.AgentClient;
+import com.volta.master.cluster.AgentCluster;
+import com.volta.model.TestConfig;
 import com.volta.stats.StatsSnapshot;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -32,24 +34,52 @@ class StatsReporterTest {
     System.setOut(new PrintStream(outputCapture));
   }
 
+  private AgentCluster singleAgentCluster() {
+    return AgentCluster.of(
+        new TestConfig("https://example.com", 10, 30), List.of("http://localhost:7070"));
+  }
+
+  private AgentCluster twoAgentCluster() {
+    return AgentCluster.of(
+        new TestConfig("https://example.com", 100, 30),
+        List.of("http://localhost:7070", "http://localhost:7071"));
+  }
+
+  private void mockStartedSingleAgent() {
+    when(agentClient.isReachable("http://localhost:7070")).thenReturn(true);
+    when(agentClient.startTestSafe(eq("http://localhost:7070"), any(TestConfig.class)))
+        .thenReturn(true);
+  }
+
+  private void mockStartedTwoAgents() {
+    when(agentClient.isReachable(anyString())).thenReturn(true);
+    when(agentClient.startTestSafe(anyString(), any(TestConfig.class))).thenReturn(true);
+  }
+
   @Test
   void shouldPollStatsEverySecond() {
-    // Verify that StatsReporter calls getStats() once per second plus once for final stats
-    StatsSnapshot mockStats = new StatsSnapshot(100, 95, 5, 50.0, 10, 200);
-    when(agentClient.getStats(anyString())).thenReturn(mockStats);
+    mockStartedSingleAgent();
+    AgentCluster cluster = singleAgentCluster();
+    cluster.startCluster(agentClient);
 
-    statsReporter.startReporting("http://localhost:7070", 3, Optional.empty());
+    StatsSnapshot mockStats = new StatsSnapshot(100, 95, 5, 50.0, 10, 200);
+    when(agentClient.getStats("http://localhost:7070")).thenReturn(mockStats);
+
+    statsReporter.startReporting(cluster, 3, Optional.empty());
 
     verify(agentClient, times(4)).getStats("http://localhost:7070");
   }
 
   @Test
   void shouldPrintLiveStatsInCorrectFormat() {
-    // Verify that live stats are printed in format [RPS: X | Success: Y% | Avg: Zms | Errors: N]
-    StatsSnapshot mockStats = new StatsSnapshot(100, 98, 2, 45.5, 10, 150);
-    when(agentClient.getStats(anyString())).thenReturn(mockStats);
+    mockStartedSingleAgent();
+    AgentCluster cluster = singleAgentCluster();
+    cluster.startCluster(agentClient);
 
-    statsReporter.startReporting("http://localhost:7070", 1, Optional.empty());
+    StatsSnapshot mockStats = new StatsSnapshot(100, 98, 2, 45.5, 10, 150);
+    when(agentClient.getStats("http://localhost:7070")).thenReturn(mockStats);
+
+    statsReporter.startReporting(cluster, 1, Optional.empty());
 
     String output = outputCapture.toString();
     assertTrue(output.contains("RPS:"));
@@ -60,11 +90,14 @@ class StatsReporterTest {
 
   @Test
   void shouldPrintFinalStatsAfterLoop() {
-    // Verify that final stats summary is printed after reporting loop completes
-    StatsSnapshot mockStats = new StatsSnapshot(100, 95, 5, 50.0, 10, 200);
-    when(agentClient.getStats(anyString())).thenReturn(mockStats);
+    mockStartedSingleAgent();
+    AgentCluster cluster = singleAgentCluster();
+    cluster.startCluster(agentClient);
 
-    statsReporter.startReporting("http://localhost:7070", 1, Optional.empty());
+    StatsSnapshot mockStats = new StatsSnapshot(100, 95, 5, 50.0, 10, 200);
+    when(agentClient.getStats("http://localhost:7070")).thenReturn(mockStats);
+
+    statsReporter.startReporting(cluster, 1, Optional.empty());
 
     String output = outputCapture.toString();
     assertTrue(output.contains("FINAL STATS"));
@@ -74,11 +107,14 @@ class StatsReporterTest {
 
   @Test
   void shouldCalculateSuccessRateCorrectly() {
-    // Verify that success rate is calculated correctly: (successCount / totalRequests) * 100
-    StatsSnapshot stats = new StatsSnapshot(100, 95, 5, 50.0, 10, 200);
-    when(agentClient.getStats(anyString())).thenReturn(stats);
+    mockStartedSingleAgent();
+    AgentCluster cluster = singleAgentCluster();
+    cluster.startCluster(agentClient);
 
-    statsReporter.startReporting("http://localhost:7070", 1, Optional.empty());
+    StatsSnapshot stats = new StatsSnapshot(100, 95, 5, 50.0, 10, 200);
+    when(agentClient.getStats("http://localhost:7070")).thenReturn(stats);
+
+    statsReporter.startReporting(cluster, 1, Optional.empty());
 
     String output = outputCapture.toString();
     assertTrue(output.contains("95") || output.contains("95.0"));
@@ -86,11 +122,14 @@ class StatsReporterTest {
 
   @Test
   void shouldHandleZeroRequests() {
-    // Verify that division by zero is handled gracefully when no requests have been sent
-    StatsSnapshot emptyStats = new StatsSnapshot(0, 0, 0, 0.0, 0, 0);
-    when(agentClient.getStats(anyString())).thenReturn(emptyStats);
+    mockStartedSingleAgent();
+    AgentCluster cluster = singleAgentCluster();
+    cluster.startCluster(agentClient);
 
-    statsReporter.startReporting("http://localhost:7070", 1, Optional.empty());
+    StatsSnapshot emptyStats = new StatsSnapshot(0, 0, 0, 0.0, 0, 0);
+    when(agentClient.getStats("http://localhost:7070")).thenReturn(emptyStats);
+
+    statsReporter.startReporting(cluster, 1, Optional.empty());
 
     String output = outputCapture.toString();
     assertTrue(output.contains("RPS: 0"));
@@ -98,23 +137,30 @@ class StatsReporterTest {
 
   @Test
   void shouldContinueOnStatsError() {
-    // Verify that StatsReporter continues operating even if getStats() throws an exception
-    when(agentClient.getStats(anyString()))
+    mockStartedSingleAgent();
+    AgentCluster cluster = singleAgentCluster();
+    cluster.startCluster(agentClient);
+
+    when(agentClient.getStats("http://localhost:7070"))
         .thenThrow(new RuntimeException("Network error"))
         .thenReturn(new StatsSnapshot(10, 10, 0, 50.0, 10, 100));
 
-    assertDoesNotThrow(
-        () -> statsReporter.startReporting("http://localhost:7070", 2, Optional.empty()));
-    verify(agentClient, atLeast(2)).getStats(anyString());
+    assertDoesNotThrow(() -> statsReporter.startReporting(cluster, 2, Optional.empty()));
+    verify(agentClient, atLeast(1)).getStats("http://localhost:7070");
+    assertTrue(outputCapture.toString().contains("WARNING: agent unavailable"));
   }
 
   @Test
   void shouldWriteCsvWithHeaderSampleAndFinalRows(@TempDir Path tempDir) throws Exception {
+    mockStartedSingleAgent();
+    AgentCluster cluster = singleAgentCluster();
+    cluster.startCluster(agentClient);
+
     Path out = tempDir.resolve("report.csv");
     StatsSnapshot mockStats = new StatsSnapshot(100, 95, 5, 50.0, 10, 200);
-    when(agentClient.getStats(anyString())).thenReturn(mockStats);
+    when(agentClient.getStats("http://localhost:7070")).thenReturn(mockStats);
 
-    statsReporter.startReporting("http://localhost:7070", 2, Optional.of(out.toString()));
+    statsReporter.startReporting(cluster, 2, Optional.of(out.toString()));
 
     List<String> lines = Files.readAllLines(out);
     assertEquals(4, lines.size(), "header + 2 sample rows + final");
@@ -125,13 +171,36 @@ class StatsReporterTest {
   }
 
   @Test
+  void shouldAggregateStatsFromMultipleAgents() {
+    mockStartedTwoAgents();
+    AgentCluster cluster = twoAgentCluster();
+    cluster.startCluster(agentClient);
+
+    StatsSnapshot firstAgent = new StatsSnapshot(50, 45, 5, 100.0, 10, 200);
+    StatsSnapshot secondAgent = new StatsSnapshot(50, 50, 0, 50.0, 20, 150);
+    when(agentClient.getStats("http://localhost:7070")).thenReturn(firstAgent);
+    when(agentClient.getStats("http://localhost:7071")).thenReturn(secondAgent);
+
+    statsReporter.startReporting(cluster, 1, Optional.empty());
+
+    String output = outputCapture.toString();
+    assertTrue(output.contains("Total Requests:"));
+    assertTrue(output.contains("100"));
+    verify(agentClient, times(2)).getStats("http://localhost:7070");
+    verify(agentClient, times(2)).getStats("http://localhost:7071");
+  }
+
+  @Test
   void shouldStopAfterSpecifiedDuration() {
-    // Verify that reporting loop stops after the specified duration (±500ms tolerance)
+    mockStartedSingleAgent();
+    AgentCluster cluster = singleAgentCluster();
+    cluster.startCluster(agentClient);
+
     StatsSnapshot mockStats = new StatsSnapshot(100, 100, 0, 50.0, 10, 100);
-    when(agentClient.getStats(anyString())).thenReturn(mockStats);
+    when(agentClient.getStats("http://localhost:7070")).thenReturn(mockStats);
 
     long startTime = System.currentTimeMillis();
-    statsReporter.startReporting("http://localhost:7070", 2, Optional.empty());
+    statsReporter.startReporting(cluster, 2, Optional.empty());
     long elapsed = System.currentTimeMillis() - startTime;
 
     assertTrue(elapsed >= 2000 && elapsed < 3000);


### PR DESCRIPTION
## What
## Summary
- Master accepts multiple `--agent=host:port` flags and orchestrates a multi-agent load test from a single CLI run
- Total RPS is split evenly across available agents via `LoadPlanner`
- Stats from all agents are aggregated into one live report and final summary via `StatsAggregator`
- Unreachable agents are skipped at startup; master fails only if no agents are available
- If an agent fails mid-test, master marks it as dead and redistributes its RPS share to surviving agents
- Agent supports dynamic RPS changes through `POST /change-rps`
- README updated with multi-agent setup, failover behavior, and agent HTTP API

## How to verify
./mvnw verify

Closes #55 